### PR TITLE
Exclusion aws-java-sdk

### DIFF
--- a/transitclockApi/pom.xml
+++ b/transitclockApi/pom.xml
@@ -51,6 +51,12 @@
 			<groupId>TheTransitClock</groupId>
 			<artifactId>transitclockCore</artifactId>
 			<version>2.0.0-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.amazonaws</groupId>
+					<artifactId>aws-java-sdk</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		 <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
There is apparently a conflict in jackson version, which makes swagger
give internal server error.