### PR TITLE
add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 *.log
 /bin/
 /.settings/
+.DS_Store
+


### PR DESCRIPTION
On OS X, these hidden files are occasionally created and should be ignored