### PR TITLE
Cast int to double to support openjdk

### DIFF
--- a/transitclockWebapp/src/main/java/org/transitclock/reports/ScheduleAdherenceController.java
+++ b/transitclockWebapp/src/main/java/org/transitclock/reports/ScheduleAdherenceController.java
@@ -115,8 +115,8 @@ public class ScheduleAdherenceController {
 		int early = 0;
 		int late = 0;
 		int ontime = 0;
-		Double earlyLimit = (usePredictionLimits.getValue() ? earlyLimitParam : scheduleEarlySeconds.getValue());
-		Double lateLimit = (usePredictionLimits.getValue() ? lateLimitParam : scheduleLateSeconds.getValue());
+		Double earlyLimit = (usePredictionLimits.getValue() ? earlyLimitParam : (double)scheduleEarlySeconds.getValue());
+		Double lateLimit = (usePredictionLimits.getValue() ? lateLimitParam : (double)scheduleLateSeconds.getValue());
 		List<Object> results = routeScheduleAdherence(startDate, numDays, startTime, endTime, routeIds, false, null);
 
 		for (Object o : results) {


### PR DESCRIPTION
Found these lines in ScheduleAdherenceController problematic when switching travis config to `openjdk`... the automatic casting of `scheduleEarlySeconds` to a double that works with the current travis config doesn't work with `openjdk`. Looking at the associated web app report UI and .jsp, the `earlyLimit` and `lateLimit` should remain doubles, and the `scheduleEarlySeconds` and `scheduleLateSeconds`, which are Integer config values, should be cast to double.