### PR TITLE
GTFS Realtime Feeds: Properly set Trip ScheduleRelationship

### DIFF
--- a/transitclock/src/main/java/org/transitclock/ipc/data/IpcPrediction.java
+++ b/transitclock/src/main/java/org/transitclock/ipc/data/IpcPrediction.java
@@ -52,6 +52,7 @@ public class IpcPrediction implements Serializable {
 	private final int gtfsStopSeq;
 	private final String tripId;
 	private final String tripPatternId;
+	private final boolean isTripUnscheduled;
 	private final String blockId;
 	// The prediction to present to the user. Can be different from
 	// actualPredictionTime in that for wait stops might want to show
@@ -141,6 +142,7 @@ public class IpcPrediction implements Serializable {
 	    this.tripId = trip != null ? trip.getId() : "";
 	    this.tripPatternId = trip != null ? trip.getTripPattern().getId() : "";
 	    this.blockId = trip != null ? trip.getBlockId() : null;
+	    this.isTripUnscheduled = trip != null && trip.isNoSchedule() && !trip.isExactTimesHeadway();
 	    this.predictionTime = predictionTime;
 	    this.actualPredictionTime = actualPredictionTime;
 	    this.atEndOfTrip = atEndOfTrip;
@@ -172,7 +174,7 @@ public class IpcPrediction implements Serializable {
 	 * because only used internally by the proxy class.
 	 */
 	private IpcPrediction(String vehicleId, String routeId, String stopId,
-			int gtfsStopSeq, String tripId, String tripPatternId,
+			int gtfsStopSeq, String tripId, String tripPatternId, boolean isTripUnscheduled,
 			String blockId, long predictionTime, long actualPredictionTime,
 			boolean atEndOfTrip, boolean schedBasedPred, long avlTime,
 			long creationTime, long tripStartEpochTime,
@@ -189,6 +191,7 @@ public class IpcPrediction implements Serializable {
 		this.trip = null;
 		this.tripId = tripId;
 		this.tripPatternId = tripPatternId;
+		this.isTripUnscheduled = isTripUnscheduled;
 		this.blockId = blockId;
 		this.predictionTime = predictionTime;
 		this.actualPredictionTime = actualPredictionTime;
@@ -226,6 +229,7 @@ public class IpcPrediction implements Serializable {
 		private int gtfsStopSeq;
 		private String tripId;
 		private String tripPatternId;
+		private boolean isTripUnscheduled;
 		private String blockId;
 		private long predictionTime;
 		private boolean atEndOfTrip;
@@ -260,6 +264,7 @@ public class IpcPrediction implements Serializable {
 			this.gtfsStopSeq = p.gtfsStopSeq;
 			this.tripId = p.tripId;
 			this.tripPatternId = p.tripPatternId;
+			this.isTripUnscheduled = p.isTripUnscheduled;
 			this.blockId = p.blockId;
 			this.predictionTime = p.predictionTime;
 			this.atEndOfTrip = p.atEndOfTrip;
@@ -299,6 +304,7 @@ public class IpcPrediction implements Serializable {
 			stream.writeInt(gtfsStopSeq);
 			stream.writeObject(tripId);
 			stream.writeObject(tripPatternId);
+			stream.writeBoolean(isTripUnscheduled);
 			stream.writeObject(blockId);
 			stream.writeLong(predictionTime);
 			stream.writeBoolean(atEndOfTrip);
@@ -344,6 +350,7 @@ public class IpcPrediction implements Serializable {
 			gtfsStopSeq = stream.readInt();
 			tripId = (String) stream.readObject();
 			tripPatternId = (String) stream.readObject();
+			isTripUnscheduled = stream.readBoolean();
 			blockId = (String) stream.readObject();
 			predictionTime = stream.readLong();
 			atEndOfTrip = stream.readBoolean();
@@ -374,7 +381,7 @@ public class IpcPrediction implements Serializable {
 		 */
 		private Object readResolve() {
 			return new IpcPrediction(vehicleId, routeId, stopId, gtfsStopSeq,
-					tripId, tripPatternId, blockId, predictionTime, 0,
+					tripId, tripPatternId, isTripUnscheduled, blockId, predictionTime, 0,
 					atEndOfTrip, schedBasedPred, avlTime, creationTime,
 					tripStartEpochTime, affectedByWaitStop, driverId,
 					passengerCount, passengerFullness, isDelayed,
@@ -459,6 +466,10 @@ public class IpcPrediction implements Serializable {
 
 	public String getTripPatternId() {
 		return tripPatternId;
+	}
+	
+	public boolean isTripUnscheduled() {
+		return isTripUnscheduled;
 	}
 	
 	public String getBlockId() {

--- a/transitclock/src/main/java/org/transitclock/ipc/data/IpcVehicleComplete.java
+++ b/transitclock/src/main/java/org/transitclock/ipc/data/IpcVehicleComplete.java
@@ -110,6 +110,7 @@ public class IpcVehicleComplete extends IpcVehicleGtfsRealtime {
 	 * @param routeName
 	 * @param tripId
 	 * @param tripPatternId
+	 * @param isTripUnscheduled
 	 * @param directionId
 	 * @param headsign
 	 * @param predictable
@@ -133,7 +134,7 @@ public class IpcVehicleComplete extends IpcVehicleGtfsRealtime {
 	private IpcVehicleComplete(String blockId,
 			BlockAssignmentMethod blockAssignmentMethod, IpcAvl avl,
 			float pathHeading, String routeId, String routeShortName,
-			String routeName, String tripId, String tripPatternId,
+			String routeName, String tripId, String tripPatternId, boolean isTripUnscheduled,
 			String directionId, String headsign, boolean predictable,
 			boolean schedBasedPred, TemporalDifference realTimeSchdAdh,
 			boolean isDelayed, boolean isLayover, long layoverDepartureTime,
@@ -145,7 +146,7 @@ public class IpcVehicleComplete extends IpcVehicleGtfsRealtime {
 			double distanceOfNextStopFromTripStart, double distanceAlongTrip, long freqStartTime, IpcHoldingTime holdingTime, double predictedLatitude, double predictedLongitude) {
 
 		super(blockId, blockAssignmentMethod, avl, pathHeading, routeId,
-				routeShortName, routeName, tripId, tripPatternId, directionId, headsign,
+				routeShortName, routeName, tripId, tripPatternId, isTripUnscheduled, directionId, headsign,
 				predictable, schedBasedPred, realTimeSchdAdh, isDelayed,
 				isLayover, layoverDepartureTime, nextStopId, nextStopName,
 				vehicleType, tripStartEpochTime, atStop, atOrNextStopId,
@@ -242,7 +243,7 @@ public class IpcVehicleComplete extends IpcVehicleGtfsRealtime {
 		private Object readResolve() {
 			return new IpcVehicleComplete(blockId, blockAssignmentMethod, avl,
 					heading, routeId, routeShortName, routeName, tripId,
-					tripPatternId, directionId, headsign, predictable,
+					tripPatternId, isTripUnscheduled, directionId, headsign, predictable,
 					schedBasedPred, realTimeSchdAdh, isDelayed, isLayover,
 					layoverDepartureTime, nextStopId, nextStopName,
 					vehicleType, tripStartEpochTime, atStop, atOrNextStopId,
@@ -304,6 +305,7 @@ public class IpcVehicleComplete extends IpcVehicleGtfsRealtime {
 				+ ", routeName=" + getRouteName() 
 				+ ", tripId=" + getTripId()
 				+ ", tripPatternId=" + getTripPatternId()
+				+ ", isTripUnscheduled=" + isTripUnscheduled()
 				+ ", directionId=" + getDirectionId()
 				+ ", headsign=" + getHeadsign()
 				+ ", predictable=" + isPredictable()

--- a/transitclockApi/src/main/java/org/transitclock/api/gtfsRealtime/GtfsRtTripFeed.java
+++ b/transitclockApi/src/main/java/org/transitclock/api/gtfsRealtime/GtfsRtTripFeed.java
@@ -143,6 +143,17 @@ public class GtfsRtTripFeed {
 					gtfsRealtimeDateFormatter.format(new Date(
 							tripStartEpochTime));
 			tripDescriptor.setStartDate(tripStartDateStr);
+
+			// Set the relation between this trip and the static schedule. ADDED and CANCELED not supported. 
+			if (firstPred.isTripUnscheduled()) {
+				// A trip that is running with no schedule associated to it - 
+				// this value is used to identify trips defined in GTFS frequencies.txt with exact_times = 0
+				tripDescriptor.setScheduleRelationship(TripDescriptor.ScheduleRelationship.UNSCHEDULED);
+			} else {
+				// Trip that is running in accordance with its GTFS schedule, 
+				// or is close enough to the scheduled trip to be associated with it.
+				tripDescriptor.setScheduleRelationship(TripDescriptor.ScheduleRelationship.SCHEDULED);
+			}
 		}
 		tripUpdate.setTrip(tripDescriptor);
 		if (firstPred.getDelay() != null)

--- a/transitclockApi/src/main/java/org/transitclock/api/gtfsRealtime/GtfsRtVehicleFeed.java
+++ b/transitclockApi/src/main/java/org/transitclock/api/gtfsRealtime/GtfsRtVehicleFeed.java
@@ -99,6 +99,18 @@ public class GtfsRtVehicleFeed {
 				String tripStartTimeStr=gtfsRealtimeTimeFormatter.format(new Date(vehicleData.getFreqStartTime()));
 				tripDescriptor.setStartTime(tripStartTimeStr);
 			}
+
+			// Set the relation between this trip and the static schedule. ADDED and CANCELED not supported.
+			if (vehicleData.isTripUnscheduled()) {
+				// A trip that is running with no schedule associated to it - 
+				// this value is used to identify trips defined in GTFS frequencies.txt with exact_times = 0
+				tripDescriptor.setScheduleRelationship(TripDescriptor.ScheduleRelationship.UNSCHEDULED);
+			} else {
+				// Trip that is running in accordance with its GTFS schedule, 
+				// or is close enough to the scheduled trip to be associated with it.
+				tripDescriptor.setScheduleRelationship(TripDescriptor.ScheduleRelationship.SCHEDULED);
+			}
+
 			vehiclePosition.setTrip(tripDescriptor);
 			
 		}


### PR DESCRIPTION
This PR implements a change to the GTFS Realtime vehicle positions and trip updates feeds generated by TheTransitClock, to properly set the trip's ScheduleRelationship.

TheTransitClock can only support `SCHEDULED` and `UNSCHEDULED` right now, and these values should be set according to the spec:

> SCHEDULED | Trip that is running in accordance with its GTFS schedule, or is close enough to the scheduled trip to be associated with it.
> UNSCHEDULED | A trip that is running with no schedule associated to it - this value is used to identify trips defined in GTFS frequencies.txt with exact_times = 0. It should not be used to describe trips not defined in GTFS frequencies.txt, or trips in GTFS frequencies.txt with exact_times = 1.

Spec reference: https://developers.google.com/transit/gtfs-realtime/reference/#enum_schedulerelationship_1

This information (whether a trip is scheduled or unscheduled) needs to be accessed when creating the GTFS Realtime feeds, but the Trip object was unavailable in the related classes - hence the addition of the `isTripUnscheduled` method and param.
