### PR TITLE
Parameterize config file location for Tomcat apps

### DIFF
--- a/transitclockApi/README.md
+++ b/transitclockApi/README.md
@@ -1,20 +1,24 @@
-This is the a REST service which provides the information required to run a web application or mobile application based on transitTime.
+This is the a REST service which provides the information required to run a web application or mobile application based on TheTransitClock.
 
 This can be built on its own by 
 ```
-cd transitTimeApi
+cd transitclockApi
 mvn install
 ```
 
 This will produce a api.war file which can be deployed on Tomcat. 
 
-You will need to configure the location of your transitimeconfig.xml file in web.xml
+You will need to configure the location of the transitclockConfig.xml file as a command line argument:
+
+`-Dtransitclock.configFiles=/path/to/your/transitclockConfig.xml`
+
+The exact place to do this depends on how you're running TheTransitClock. In Eclipse, add this as a VM argument in the run configuration for Tomcat. In a bash script, add it to `CATALINA_OPTS` before Tomcat starts up.
 
 This server talks to core using RMI calls to get the information to support the REST service calls.
 
-To access the service a key is required to be provided in the URL. This key is compared against a key in the database. You can use the CreateAPIKey application in transiTime to create a test/demo key.
+To access the service a key is required to be provided in the URL. This key is compared against a key in the database. You can use the CreateAPIKey application in TheTransitClock to create a test/demo key.
 
-The tables that store this information are create by running the ddl_xxxx_org_transitime_db_webstructs.sql in the database.(Where xxxx is the type of database you are using)
+The tables that store this information are create by running the ddl_xxxx_org_transitime_db_webstructs.sql in the database. (Where xxxx is the type of database you are using)
 ```
 Example URLs
 

--- a/transitclockApi/src/main/webapp/WEB-INF/web.xml
+++ b/transitclockApi/src/main/webapp/WEB-INF/web.xml
@@ -7,7 +7,7 @@
 	<context-param>
 		<param-name>transitime_config_file_location</param-name>
 		<!-- Set to customized properties file with db config info and such -->
-		 <param-value>/Users/vperez/git/transitime/transitclockWebapp/src/main/resources/transiTimeconfig.xml</param-value>      
+		 <param-value>${transitclock.configFiles}</param-value>      
 	</context-param>
 
 

--- a/transitclockWebapp/.gitignore
+++ b/transitclockWebapp/.gitignore
@@ -1,8 +1,4 @@
 /target/
 /.settings/
 /target/
-<<<<<<< HEAD
 /bin/
-=======
-/bin
->>>>>>> 7f9fa2df466fd81ee86c633c4151b0dbb0c583f2

--- a/transitclockWebapp/README.md
+++ b/transitclockWebapp/README.md
@@ -1,12 +1,18 @@
-This is the web application for transitTime and can be built by 
+This is the web application for TheTransitClock and can be built by 
 
 ```
-cd transitimeWebapp
+cd transitclockWebapp
 maven install -DskipTests
 ```
 
 This produces a war file for deployment web.war in the target directory.
 
-You will need to configure the location of the transitTimeConfig.xml file in the web.xml file. The transitTimeConfig.xml file in turn is used to specify the location of the database and the hibernate file.
+You will need to configure the location of the transitclockConfig.xml file as a command line argument:
 
-You will also need to configure the key for accessing the transitimeApi in the template/includes.jsp file. You can use the CreateAPIKey application in transiTime to create a test/demo key. This you may already have done as part of the setup of transitimeApi.
+`-Dtransitclock.configFiles=/path/to/your/transitclockConfig.xml`
+
+The exact place to do this depends on how you're running TheTransitClock. In Eclipse, add this as a VM argument in the run configuration for Tomcat. In a bash script, add it to `CATALINA_OPTS` before Tomcat starts up.
+
+The transitclockConfig.xml file in turn is used to specify the location of the database and the hibernate file.
+
+You will also need to configure the key for accessing the transitclockApi in the template/includes.jsp file. You can use the CreateAPIKey application in TheTransitClock to create a test/demo key. This you may already have done as part of the setup of transitclockApi.

--- a/transitclockWebapp/src/main/webapp/WEB-INF/web.xml
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/web.xml
@@ -6,7 +6,7 @@
   <context-param>
       <param-name>transitime_config_file_location</param-name>
       <!-- Set to customized properties file with db config info and such -->     
-      <param-value>/usr/local/transitclock/config/transitclockConfig.xml</param-value>      
+      <param-value>${transitclock.configFiles}</param-value>      
       
   </context-param>
 


### PR DESCRIPTION
The two web apps (transitclockApi and transitclockWebapp) currently have hardcoded paths to the transitclockConfig.xml file. This PR switches this to a Java System Property, which allows for dynamically changing the config file path. Instead of editing the web.xml files directly, you will need to specify the path as a command line argument:

`-Dtransitclock.configFiles=/path/to/your/transitclockConfig.xml`

The exact place to do this depends on how you're running TheTransitClock. In Eclipse, add this as a VM argument in the run configuration for Tomcat. In a bash script, add it to `CATALINA_OPTS` before Tomcat starts up.