### PR TITLE
Remove timed out vehicles from VehicleDataCache (configurable)

### DIFF
--- a/transitclock/src/main/java/org/transitclock/core/AvlProcessor.java
+++ b/transitclock/src/main/java/org/transitclock/core/AvlProcessor.java
@@ -237,23 +237,12 @@ public class AvlProcessor {
 	}
 
 	/**
-	 * Marks the vehicle as not being predictable and that the assignment has
-	 * been grabbed. Updates VehicleDataCache. Creates and logs a VehicleEvent
-	 * explaining the situation.
+	 * Removes the vehicle from the VehicleDataCache.
 	 * 
-	 * @param vehicleState
-	 *            The vehicle to be made unpredictable
-	 * @param eventDescription
-	 *            A longer description of why vehicle being made unpredictable
-	 * @param vehicleEvent
-	 *            A short description from VehicleEvent class for labeling the
-	 *            event.
+	 * @param vehicleId
+	 *            The vehicle to remove
 	 */
-	public void makeVehicleUnpredictableAndRemoveFromVehicleDataCache(
-			String vehicleId, String eventDescription, String vehicleEvent) {
-		makeVehicleUnpredictable(vehicleId, eventDescription, vehicleEvent);
-
-		// Remove vehicle from VehicleDataCache
+	public void removeFromVehicleDataCache(String vehicleId) {
 		VehicleDataCache.getInstance().removeVehicle(vehicleId);
 	}
 	
@@ -1233,9 +1222,6 @@ public class AvlProcessor {
 								+ " ended for vehicle so it was made unpredictable.";
 				makeVehicleUnpredictableAndTerminateAssignment(vehicleState,
 						eventDescription, VehicleEvent.END_OF_BLOCK);
-
-				// Remove vehicle from VehicleDataCache
-				VehicleDataCache.getInstance().removeVehicle(vehicleState.getVehicleId());
 
 				// Return that end of block reached
 				return true;

--- a/transitclock/src/main/java/org/transitclock/core/AvlProcessor.java
+++ b/transitclock/src/main/java/org/transitclock/core/AvlProcessor.java
@@ -1234,6 +1234,9 @@ public class AvlProcessor {
 				makeVehicleUnpredictableAndTerminateAssignment(vehicleState,
 						eventDescription, VehicleEvent.END_OF_BLOCK);
 
+				// Remove vehicle from VehicleDataCache
+				VehicleDataCache.getInstance().removeVehicle(vehicleState.getVehicleId());
+
 				// Return that end of block reached
 				return true;
 			}

--- a/transitclock/src/main/java/org/transitclock/core/AvlProcessor.java
+++ b/transitclock/src/main/java/org/transitclock/core/AvlProcessor.java
@@ -237,6 +237,27 @@ public class AvlProcessor {
 	}
 
 	/**
+	 * Marks the vehicle as not being predictable and that the assignment has
+	 * been grabbed. Updates VehicleDataCache. Creates and logs a VehicleEvent
+	 * explaining the situation.
+	 * 
+	 * @param vehicleState
+	 *            The vehicle to be made unpredictable
+	 * @param eventDescription
+	 *            A longer description of why vehicle being made unpredictable
+	 * @param vehicleEvent
+	 *            A short description from VehicleEvent class for labeling the
+	 *            event.
+	 */
+	public void makeVehicleUnpredictableAndRemoveFromVehicleDataCache(
+			String vehicleId, String eventDescription, String vehicleEvent) {
+		makeVehicleUnpredictable(vehicleId, eventDescription, vehicleEvent);
+
+		// Remove vehicle from VehicleDataCache
+		VehicleDataCache.getInstance().removeVehicle(vehicleId);
+	}
+	
+	/**
 	 * Looks at the previous AVL reports to determine if vehicle is actually
 	 * moving. If it is not moving then the vehicle is made unpredictable. Uses
 	 * the system properties transitclock.core.timeForDeterminingNoProgress and

--- a/transitclock/src/main/java/org/transitclock/core/dataCache/VehicleDataCache.java
+++ b/transitclock/src/main/java/org/transitclock/core/dataCache/VehicleDataCache.java
@@ -539,4 +539,15 @@ public class VehicleDataCache {
 		updateVehicleIdsByBlockMap(originalVehicle, vehicle);
 		updateVehiclesMap(vehicle);
 	}
+
+	/**
+	 * Removes a vehicle from the vehiclesMap
+	 * 
+	 * @param vehicleId
+	 *            The id of the vehicle to remove from the vehiclesMap
+	 */
+	public void removeVehicle(String vehicleId) {
+		logger.debug("Removing from VehicleDataCache vehiclesMap vehicleId={}", vehicleId);
+		vehiclesMap.remove(vehicleId);
+	}
 }


### PR DESCRIPTION
Add a configuration option (`transitclock.timeout.removeTimedOutVehiclesFromVehicleDataCache`) and supporting methods to the `TimeoutHandlerModule` that allows timed out vehicles to be removed from the `VehicleDataCache`.

Retains existing behavior by default (timed out vehicles will still appear in the map views in the webapp and in feeds like the GTFS Realtime Vehicle Positions feed).

Set `transitclock.timeout.removeTimedOutVehiclesFromVehicleDataCache` to `true` to remove timed out vehicles from the cache, so they won't show up in the GTFS Realtime feeds or on the map.
