### PR TITLE
Add config to use outputPathsAndStopsForGraphing debug function without recompile

### DIFF
--- a/transitclock/src/main/java/org/transitclock/gtfs/GtfsData.java
+++ b/transitclock/src/main/java/org/transitclock/gtfs/GtfsData.java
@@ -256,6 +256,14 @@ public class GtfsData {
 					+ "name of the last stop, won't disambiguate if the last "
 					+ "stops for the trips with the same headsign differ by "
 					+ "less than this amount.");
+
+	private static StringConfigValue outputPathsAndStopsForGraphingRouteIds = 
+		new StringConfigValue("transitclock.gtfs.outputPathsAndStopsForGraphingRouteIds", 
+			null, // Default of null means don't output any routes
+			"Outputs data for specified routes grouped by trip pattern."
+			+ "The resulting data can be visualized on a map by cutting"
+			+ "and pasting it in to http://www.gpsvisualizer.com/map_input"
+			+ "Separate multiple route ids with commas");
 	
 	// Logging
 	public static final Logger logger = 
@@ -2546,6 +2554,16 @@ public class GtfsData {
 	
 	/*************************** Main Public Methods **********************/
 	
+	public void outputRoutesForGraphing() {
+		if (outputPathsAndStopsForGraphingRouteIds.getValue() == null)
+			return;
+		
+		String[] routeIds = outputPathsAndStopsForGraphingRouteIds.getValue().split(",");
+		for (String routeId : routeIds) {
+			outputPathsAndStopsForGraphing(routeId);
+		}
+	}
+
 	/**
 	 * Outputs data for specified route grouped by trip pattern.
 	 * The resulting data can be visualized on a map by cutting
@@ -2701,8 +2719,8 @@ public class GtfsData {
 		// MBTA commuter rail.
 		trimCalendars();
 		
-		// debugging
-		//outputPathsAndStopsForGraphing("8699");
+		// Optionally output routes for debug graphing		
+		outputRoutesForGraphing();
 		
 		// Now process travel times and update the Trip objects. 
 		TravelTimesProcessorForGtfsUpdates travelTimesProcesssor =


### PR DESCRIPTION
There is an interesting debug function in GtfsData that outputs structured data after TheTransitClock processes the GTFS shapes. You can paste the output into gpsvisualizer.com, which amazingly still works. This can be helpful to see how different config parameters affect the way TheTransitClock divides up, simplifies, offsets, or otherwise processes GTFS shapes. This commit makes it easier to use this function - instead of hard coding and commenting/uncommenting the existing line in GtfsFileProcessor, you can set the new `transitclock.gtfs.outputPathsAndStopsForGraphingRouteIds` config option to one or more (comma separated) route ids. When you set the value, you'll get some CSV data dumped to STDERR when you run GtfsFileProcessor (i.e. import GTFS static data). Copy and paste that into http://www.gpsvisualizer.com/map_input to get a debug view of the processed shapes and stops.

The config value is null by default and will not add any debug output unless it is set.