### PR TITLE
Add additional config params

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
                 <module>transitclock</module>
                 <module>transitclockApi</module>
               	<module>transitclockWebapp</module>
-		 		<module>transitclockQuickStart</module>
-		 		<module>transitclockTraccarClient</module>
-		 		<module>transitclockBarefootClient</module>
+ 		<module>transitclockQuickStart</module>
+ 		<module>transitclockTraccarClient</module>
+ 		<module>transitclockBarefootClient</module>
             </modules>
         </profile>
     </profiles>

--- a/transitclock/src/main/java/org/transitclock/core/AvlProcessor.java
+++ b/transitclock/src/main/java/org/transitclock/core/AvlProcessor.java
@@ -121,6 +121,15 @@ public class AvlProcessor {
 	          "transitclock.core.maxMatchDistanceFromAVLRecord",
 	          500.0,
 	          "For logging distance between spatial match and actual AVL assignment ");
+	 
+	 private static BooleanConfigValue ignoreInactiveBlocks =
+			 new BooleanConfigValue(
+					 "transitclock.core.ignoreInactiveBlocks",
+					 true,
+					 "If the block isn't active at this time then ignore it. This way " 
+					 + "don't look at each trip to see if it is active which is important " 
+					 + "because looking at each trip means all the trip data including "
+					 + "travel times needs to be lazy loaded, which can be slow.");
 
 	
   private double getMaxMatchDistanceFromAVLRecord() {
@@ -683,7 +692,8 @@ public class AvlProcessor {
 			// don't look at each trip to see if it is active which is important
 			// because looking at each trip means all the trip data including
 			// travel times needs to be lazy loaded, which can be slow.
-			if (!block.isActive(avlReport.getDate())) {
+			// Override by setting transitclock.core.ignoreInactiveBlocks to false
+			if (!block.isActive(avlReport.getDate()) && ignoreInactiveBlocks.getValue()) {
 				if (logger.isDebugEnabled()) {
 					logger.debug("For vehicleId={} ignoring block ID {} with "
 							+ "start_time={} and end_time={} because not "

--- a/transitclock/src/main/java/org/transitclock/core/BlocksInfo.java
+++ b/transitclock/src/main/java/org/transitclock/core/BlocksInfo.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.transitclock.applications.Core;
+import org.transitclock.config.IntegerConfigValue;
 import org.transitclock.db.structs.Block;
 import org.transitclock.gtfs.DbConfig;
 import org.transitclock.utils.Time;
@@ -37,6 +38,10 @@ import org.transitclock.utils.Time;
  *
  */
 public class BlocksInfo {
+	
+	private static IntegerConfigValue blockactiveForTimeBeforeSecs=new IntegerConfigValue("transitclock.core.blockactiveForTimeBeforeSecs", new Integer(0), "Now many seconds before the start of a block it will be considered active.");
+	private static IntegerConfigValue blockactiveForTimeAfterSecs=new IntegerConfigValue("transitclock.core.blockactiveForTimeAfterSecs", new Integer(-1), "Now many seconds after the end of a block it will be considered active.");
+	
 
 	/********************** Member Functions **************************/
 
@@ -87,7 +92,7 @@ public class BlocksInfo {
 	 * @return List of currently active blocks. Will not be null.
 	 */
 	public static List<Block> getCurrentlyActiveBlocks() {
-		return getCurrentlyActiveBlocks(null, null, 0, -1);
+		return getCurrentlyActiveBlocks(null, null,blockactiveForTimeBeforeSecs.getValue(), blockactiveForTimeAfterSecs.getValue());
 	}
 	
 	/**

--- a/transitclock/src/main/java/org/transitclock/core/SpatialMatcher.java
+++ b/transitclock/src/main/java/org/transitclock/core/SpatialMatcher.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.transitclock.config.BooleanConfigValue;
 import org.transitclock.configData.AvlConfig;
 import org.transitclock.configData.CoreConfig;
 import org.transitclock.db.structs.AvlReport;
@@ -72,6 +73,7 @@ public class SpatialMatcher {
 	private static final Logger logger = 
 			LoggerFactory.getLogger(SpatialMatcher.class);
 
+	private static BooleanConfigValue spatialMatchToLayoversAllowedForAutoAssignment=new BooleanConfigValue("transitclock.core.spatialMatchToLayoversAllowedForAutoAssignment", false, "Allow auto assigner consider spatial matches to layovers. Experimental.");
 	/********************** Member Functions **************************/
 
 	/**
@@ -399,14 +401,14 @@ public class SpatialMatcher {
 						MatchingType.AUTO_ASSIGNING_MATCHING);
 
 		// Filter out the ones that are layovers
-		List<SpatialMatch> spatialMatchesWithoutLayovers = 
+		List<SpatialMatch> spatialMatches = 
 				new ArrayList<SpatialMatch>();
 		for (SpatialMatch spatialMatch : allSpatialMatches) {
-			if (!spatialMatch.isLayover())
-				spatialMatchesWithoutLayovers.add(spatialMatch);
+			if (!spatialMatch.isLayover() || spatialMatchToLayoversAllowedForAutoAssignment.getValue())
+				spatialMatches.add(spatialMatch);
 		}		
 
-		return spatialMatchesWithoutLayovers;
+		return spatialMatches;
 	}
 
 	/**


### PR DESCRIPTION
-- transitclock.avl.playbackSkipIntervalMinutes
-- transitclock.avl.playbackStartDelayMinutes
-- transitclock.core.ignoreInactiveBlocks
-- transitclock.core.blockactiveForTimeBeforeSecs
-- transitclock.core.blockactiveForTimeAfterSecs
-- transitclock.core.spatialMatchToLayoversAllowedForAutoAssignment

Work originally completed by @scrudden and @nselikoff in @omnimodal fork