### PR TITLE
Fix the Barefoot Matcher Format

### DIFF
--- a/transitclock/src/main/java/org/transitclock/custom/traccar/TraccarBarefootAVLModule.java
+++ b/transitclock/src/main/java/org/transitclock/custom/traccar/TraccarBarefootAVLModule.java
@@ -113,7 +113,19 @@ public class TraccarBarefootAVLModule extends TraccarAVLModule {
 		}
 		PrintWriter writer = new PrintWriter(client.getOutputStream());
 		BufferedReader reader = new BufferedReader(new InputStreamReader(client.getInputStream()));
-		writer.println(sample.toString());
+       //writer.println(sample.toString());
+	
+		
+		//new barefoot format 
+		
+	        String s = sample.toString();
+
+		s= s+"]";
+		s="["+s;
+
+		writer.println(s);
+		writer.flush();
+		
 		writer.flush();
 
 		String code = reader.readLine();


### PR DESCRIPTION
The barefoot json format now is


[{}]  , so it was failing to send the request .  I have modified it to match it. 