### PR TITLE
FIX issue #241

### DIFF
--- a/transitclock/src/main/java/org/transitclock/db/structs/StopPath.java
+++ b/transitclock/src/main/java/org/transitclock/db/structs/StopPath.java
@@ -128,6 +128,13 @@ public class StopPath implements Serializable, Lifecycle {
 	@Transient
 	private List<VectorWithHeading> vectors = null;
 	
+	/**
+	 * This is used just to get better location of the bustop
+	 * where bestmatch is done.
+	 */
+	@Transient
+	private Double shapeDistanceTraveled;
+	
 	// Because Hibernate requires objects with composite IDs to be Serializable
 	private static final long serialVersionUID = 8170734640228933095L;
 
@@ -149,6 +156,7 @@ public class StopPath implements Serializable, Lifecycle {
 	 * @param waitStop
 	 * @param scheduleAdherenceStop
 	 * @param breakTime
+	 * @param shapeDistanceTraveled 
 	 */
 	public StopPath(int configRev,
 			String pathId, 
@@ -161,7 +169,7 @@ public class StopPath implements Serializable, Lifecycle {
 			boolean scheduleAdherenceStop,
 			Integer breakTime,
 			Double maxDistance,
-			Double maxSpeed) {
+			Double maxSpeed, Double shapeDistanceTraveled) {
 		this.configRev = configRev;
 		this.stopPathId = pathId;
 		this.stopId = stopId;
@@ -177,6 +185,7 @@ public class StopPath implements Serializable, Lifecycle {
 		this.breakTime = breakTime;
 		this.maxDistance = maxDistance;
 		this.maxSpeed = maxSpeed;
+		this.shapeDistanceTraveled=shapeDistanceTraveled;
 	}
 
 	/**
@@ -198,6 +207,7 @@ public class StopPath implements Serializable, Lifecycle {
 		this.breakTime = null;
 		this.maxDistance = null;
 		this.maxSpeed = null;
+		
 		
 	}
 	
@@ -235,7 +245,13 @@ public class StopPath implements Serializable, Lifecycle {
 			return previousStopId + "_to_" + stopId;
 		}
 	}
-		
+	public Double getShapeDistanceTraveled() {
+		return shapeDistanceTraveled;
+	}
+
+	public void setShapeDistanceTraveled(Double shapeDistanceTraveled) {
+		this.shapeDistanceTraveled = shapeDistanceTraveled;
+	}
 	/**
 	 * Returns the distance to travel along the path. Summation of 
 	 * all of the path segments.

--- a/transitclock/src/main/java/org/transitclock/gtfs/GtfsData.java
+++ b/transitclock/src/main/java/org/transitclock/gtfs/GtfsData.java
@@ -1288,7 +1288,7 @@ public class GtfsData {
 			StopPath path = new StopPath(revs.getConfigRev(), pathId,
 					stopId, gtfsStopTime.getStopSequence(), lastStopInTrip,
 					trip.getRouteId(), layoverStop, waitStop,
-					scheduleAdherenceStop, gtfsRoute.getBreakTime(), gtfsStopTime.getMaxDistance(), gtfsStopTime.getMaxSpeed());
+					scheduleAdherenceStop, gtfsRoute.getBreakTime(), gtfsStopTime.getMaxDistance(), gtfsStopTime.getMaxSpeed(),gtfsStopTime.getShapeDistTraveled());
 			paths.add(path);
 			
 			previousStopId = stopId;

--- a/transitclock/src/main/java/org/transitclock/gtfs/StopPathProcessor.java
+++ b/transitclock/src/main/java/org/transitclock/gtfs/StopPathProcessor.java
@@ -222,18 +222,15 @@ public class StopPathProcessor {
 		double stopToShapeDistance;
 		double distanceAlongShape;
 		Location matchLocation;
-		
+		double distanceAlongPattern;
 		@Override
 		public String toString() {
-			return "BestMatch [" 
-					+ "shapeIndex=" + shapeIndex
-					+ ", stopToShapeDistance=" 
-						+ Geo.distanceFormat(stopToShapeDistance)
-					+ ", distanceAlongShape=" 
-						+ Geo.distanceFormat(distanceAlongShape)
-					+ ", matchLocation=" + matchLocation
-					+ "]";
+			return "BestMatch [shapeIndex=" + shapeIndex + ", stopToShapeDistance=" + stopToShapeDistance
+					+ ", distanceAlongShape=" + distanceAlongShape + ", matchLocation=" + matchLocation
+					+ ", distanceAlongPattern=" + distanceAlongPattern + "]";
 		}
+		
+
 	}
 	/**
 	 * Determines and returns the best match of the stop to a shape.
@@ -247,14 +244,16 @@ public class StopPathProcessor {
 	 */
 	private BestMatch determineBestMatch(TripPattern tripPattern,
 			int stopIndex, int previousShapeIndex,
-			double previousDistanceAlongShape, List<Location> shapeLocs) {
+			double previousDistanceAlongShape, List<Location> shapeLocs,double previousDistanceAlongPattern) {
 		// Value to be returned
 		BestMatch bestMatch = null;
 		
 		// Determine the stop for the trip pattern
 		String stopId = tripPattern.getStopId(stopIndex);
 		Stop stop = stopsMap.get(stopId);
-		
+		StopPath stopPath= tripPattern.getStopPath(stopIndex);
+		//if(stopId.startsWith("GLN") )
+		//	System.out.println("AQUI COMINEZA "+stopId);
 		// Determine the previous stop for the trip pattern (can be null)
 		Stop previousStop = null;
 		if (stopIndex > 0) {
@@ -282,6 +281,7 @@ public class StopPathProcessor {
 		// when add in length of current vector it indeed shows how
 		// far along shapes been looking to match current stop.
 		double distanceAlongShapesExamined = -previousDistanceAlongShape;
+		double dististanceOverPattern = previousDistanceAlongPattern;
 		for (int shapeIndex = previousShapeIndex; 
 			 shapeIndex < shapeLocs.size()-1; 
 			 ++shapeIndex) {
@@ -290,6 +290,17 @@ public class StopPathProcessor {
 			Location loc1 = shapeLocs.get(shapeIndex+1);
 			Vector shapeVector = new Vector(loc0, loc1);
 			
+			
+			dististanceOverPattern+=shapeVector.length();
+			//This is the same segment than the previous one
+			//so we should only add the part form the last part
+			if(previousShapeIndex==shapeIndex)
+			{
+				dististanceOverPattern-=previousDistanceAlongShape;
+			}
+			
+			
+//			stop.get
 			// Determine distance of stop to the current shape
 			double stopToShapeDistance = stop.getLoc().distance(shapeVector);
 			// If this is the best fit so far, but 
@@ -322,9 +333,16 @@ public class StopPathProcessor {
 					bestMatch.matchLocation =
 							shapeVector
 									.locAlongVector(bestMatch.distanceAlongShape);
+					
+					bestMatch.distanceAlongPattern=dististanceOverPattern-(shapeVector.length()-bestMatch.distanceAlongShape);
 				}
 			}
-			
+			if(stopPath.getShapeDistanceTraveled()!=null && bestMatch!=null)
+			{
+				
+				if(Math.abs(bestMatch.distanceAlongPattern-stopPath.getShapeDistanceTraveled())<10)
+					break;
+			}
 			// Keep track of how far along the shapes have examined. If
 			// have looked for much further than the distance between the
 			// stops then have looked far enough. Don't want to look too
@@ -402,7 +420,8 @@ public class StopPathProcessor {
 						tripPattern.toStringListingTripIds() );
 			}
 		}
-		
+		logger.debug(" bestMatch {} expected distanceAlongPattern {}",bestMatch,stopPath.getShapeDistanceTraveled());
+		System.out.println("bestMatch "  +bestMatch+" "+stopPath.getShapeDistanceTraveled());
 		// Return results
 		return bestMatch;
 	}
@@ -428,14 +447,14 @@ public class StopPathProcessor {
 		double previousDistanceAlongShape = 0.0; 
 		Location previousLocation = null;
 		int numberOfStopsTooFarAway = 0;
-		
+		double previousDistanceAlongPattern=0.0;
 		// For each stop for the trip pattern...
 		for (int stopIndex = 0; 
 				stopIndex < tripPattern.getStopPaths().size(); 
 				++stopIndex) {
 			// Determine which shape the stop matches to
 			BestMatch bestMatch = determineBestMatch(tripPattern, stopIndex,
-					previousShapeIndex, previousDistanceAlongShape, shapeLocs);
+					previousShapeIndex, previousDistanceAlongShape, shapeLocs,previousDistanceAlongPattern);
 			// Keep track of how many stops too far away from path so can log
 			// the number for the entire system
 			if (bestMatch.stopToShapeDistance > maxStopToPathDistance) {
@@ -510,6 +529,7 @@ public class StopPathProcessor {
 			// Prepare for looking at next stop
 			previousShapeIndex = bestMatch.shapeIndex;
 			previousDistanceAlongShape = bestMatch.distanceAlongShape;
+			previousDistanceAlongPattern= bestMatch.distanceAlongPattern;
 		} // End of for each stop for the trip pattern		
 		
 		// If there errors with stops being too far away from the stopPaths then

--- a/transitclock/src/main/java/org/transitclock/gtfs/gtfsStructs/GtfsStopTime.java
+++ b/transitclock/src/main/java/org/transitclock/gtfs/gtfsStructs/GtfsStopTime.java
@@ -137,7 +137,7 @@ public class GtfsStopTime extends CsvBase implements Comparable<GtfsStopTime> {
 		dropOffType = getOptionalValue(record, "drop_off_type");
 		
 		String shapeDistTraveledStr = getOptionalValue(record, "shape_dist_traveled");
-		shapeDistTraveled = shapeDistTraveledStr == null ? 
+		shapeDistTraveled = shapeDistTraveledStr == null || shapeDistTraveledStr.trim().isEmpty() ? 
 				null : Double.parseDouble(shapeDistTraveledStr);
 		
 		timepointStop = getOptionalBooleanValue(record, "timepoint");


### PR DESCRIPTION
There is a special case, if route passes over the same arc (street), it
is still possible to select the incorrect shape segment for the bus stop
if the field shapedistancetraveled is not provided.