### PR TITLE
Update pom.xml to get one-jar-boot from Maven Central

### DIFF
--- a/transitclock/pom.xml
+++ b/transitclock/pom.xml
@@ -12,14 +12,7 @@
 
 		<!-- Needed to fix problem with one-jar not working with AWS SDK. Was getting 
 			error message "Fatal: Failed to load the internal config for AWS" -->
-		<repository>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-			<id>bintray-kevinlee-maven</id>
-			<name>bintray</name>
-			<url>http://dl.bintray.com/kevinlee/maven</url>
-		</repository>
+
 	</repositories>
 
 	<pluginRepositories>
@@ -48,9 +41,9 @@
 		<!-- Needed to fix problem with one-jar not working with AWS SDK. Was getting
 			error message "Fatal: Failed to load the internal config for AWS" -->
 		<dependency>
-			<groupId>com.simontuffs</groupId>
+			<groupId>io.kevinlee</groupId>
 			<artifactId>one-jar-boot</artifactId>
-			<version>0.97.3</version>
+			<version>0.97.4</version>
 		</dependency>
 
 		<!-- Database related, including c3p0 production quality connector. Note:


### PR DESCRIPTION
The original bintray link is not working anymore and causing build issues.